### PR TITLE
Add Oh My Zsh installation and set zsh as default shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ AutoKali is a tool designed to automate the deployment of a custom environment o
 
 Also automates some config by downloading a dotfiles repository.
 
-## Pre-installation steps
-
-Install Oh My Zsh and set zsh default shell (on the new user account):
-
-```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-```
-
 ## Download
 
 Clone this repository to your local machine and give the installation script execution permissions.

--- a/src/custom.sh
+++ b/src/custom.sh
@@ -31,6 +31,20 @@ function customDesktop(){
 	dpkg -i /tmp/bat.deb > /dev/null 2>&1
 	check "Installing bat"
 
+    # Install Oh My Zsh
+    info "Installing Oh My Zsh"
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" > /dev/null 2>&1
+    check "Installing Oh My Zsh"
+
+    # Set zsh as default shell if not already set
+    info "Setting zsh as default shell"
+    if [ "$SHELL" != "/bin/zsh" ]; then
+        chsh -s /bin/zsh
+        check "Setting zsh as default shell"
+    else
+        info "zsh is already the default shell"
+    fi
+
     # Fonts
 	info "Installing font (Hack Nerd Font)"
 	cd /usr/local/share/fonts/ 2>/dev/null


### PR DESCRIPTION
Add installation of Oh My Zsh and set zsh as default shell in `src/custom.sh`

* **Install Oh My Zsh**
  - Add command to install Oh My Zsh in the `customDesktop` function.
* **Set zsh as default shell**
  - Add command to set zsh as the default shell if not already set in the `customDesktop` function.
* **Update README.md**
  - Remove the pre-installation steps section.

